### PR TITLE
Update controlnet_pipeline.py

### DIFF
--- a/controlnet_pipeline.py
+++ b/controlnet_pipeline.py
@@ -606,7 +606,7 @@ class ControlnetCogVideoXPipeline(DiffusionPipeline, CogVideoXLoraLoaderMixin):
                 prompt_embeds = prompt_embeds.to(dtype=self.transformer.dtype)
                 
                 controlnet_states = None
-                if (controlnet_guidance_start < current_sampling_percent < controlnet_guidance_end):
+                if (controlnet_guidance_start <= current_sampling_percent <= controlnet_guidance_end):
                     # extract controlnet hidden state
                     controlnet_states = self.controlnet(
                         hidden_states=latent_model_input,


### PR DESCRIPTION
During inference, the control signals should be added between [start, end] instead of (start, end). Typically start is step 0, and we would like to add control at step 0.